### PR TITLE
Fixed for PUT / POST / DELETE requests

### DIFF
--- a/utils/utils.js
+++ b/utils/utils.js
@@ -117,8 +117,12 @@ utils.buildParams = buildParams;
 
 function makeParams(params, data){
 	const needed_params = ['version', 'timestamp', 'nonce', 'consumer_key', 'token', 'signature_method'];
-	for(var k in data){
-		params[k] = data[k];
+	if(params.method === "GET") {
+
+		for(var k in data){
+			params[k] = data[k];
+		}
+
 	}
 	params = sortObject(params);
 	for(var k of needed_params){


### PR DESCRIPTION
Was playing around with your library, and noticed that all PUT / POST / DELETE request would be declined by Cardmarket, as the Signature you're generating is based off data, which changes if you use any of the above methods.

Added a check, to make sure data dosen't affect the signature.